### PR TITLE
Fixed incorrect call to logging.debug() that transparently adds a handle...

### DIFF
--- a/rfc6266.py
+++ b/rfc6266.py
@@ -23,6 +23,9 @@ import os.path
 import re
 import sys
 
+LOGGER = logging.getLogger('rfc6266')
+LOGGER.addHandler(logging.NullHandler)
+
 __all__ = (
     'ContentDisposition',
     'parse_headers',
@@ -170,7 +173,7 @@ def parse_headers(content_disposition, location=None, relaxed=False):
     """Build a ContentDisposition from header values.
     """
 
-    logging.debug(
+    LOGGER.debug(
         'Content-Disposition %r, Location %r', content_disposition, location)
 
     if content_disposition is None:


### PR DESCRIPTION
...r to the root logger

Calling `logging.debug()` directly causes a `logging.StreamHandler` to be added to the default root logger `logging.getLogger()`.

This has terrible consequences when one wants to keep control over the handlers of the root logger.

The proposed change fixes that issues while keeping the log output if needed.
