### PR TITLE
Latest pytest-localserver supports Python 3

### DIFF
--- a/test_rfc6266.py
+++ b/test_rfc6266.py
@@ -23,7 +23,7 @@ def test_parsing():
     assert cd.filename_unsafe == u'€ rates'
 
 
-@pytest.mark.skipif("sys.version_info >= (3,0)")
+@pytest.mark.skipif("(3,0) <= sys.version_info < (3,3)")
 def test_httplib2(httpserver):
     httplib2 = pytest.importorskip('httplib2')
     http = httplib2.Http()
@@ -33,7 +33,7 @@ def test_httplib2(httpserver):
     assert parse_httplib2_response(resp).filename_unsafe == 'a b='
 
 
-@pytest.mark.skipif("sys.version_info >= (3,0)")
+@pytest.mark.skipif("(3,0) <= sys.version_info < (3,3)")
 def test_requests(httpserver):
     requests = pytest.importorskip('requests')
     httpserver.serve_content('eep', headers={

--- a/tox.ini
+++ b/tox.ini
@@ -4,22 +4,13 @@ envlist=py27,py26,py32,py33,pypy
 [testenv]
 deps=
     pytest
-    pytest-localserver
+    pytest-localserver>=0.3
     httplib2
     requests
 
 commands=py.test --pyargs test_rfc6266
 
-[testenv:py32]
-# pytest-localserver isn't py3k-compatible;
-# httplib2 and requests can't be tested
-deps=
-    pytest
 # Changedir is a hack to prevent test discovery from finding the non-2to3
 # source. We want tests to be import-based only.
-changedir=.tox
-
-[testenv:py33]
-deps=pytest
 changedir=.tox
 


### PR DESCRIPTION
The latest version of pytest-localserver (version 0.3) supports Python 2.6 - 2.7 and 3.3+
