### PR TITLE
NullHandler should be an instance, not a class

### DIFF
--- a/rfc6266.py
+++ b/rfc6266.py
@@ -25,7 +25,7 @@ import sys
 
 LOGGER = logging.getLogger('rfc6266')
 try:
-    LOGGER.addHandler(logging.NullHandler)
+    LOGGER.addHandler(logging.NullHandler())
 except AttributeError:
     pass
 


### PR DESCRIPTION
The logger expects a NullHandler instance, not a class. Otherwise, if you run this in an environment without a logger already set up, it raises an AttributeError as 'level' is defined on the instance, not the class.
