### PR TITLE
Setup additional disposition params for Content-disposition build

### DIFF
--- a/rfc6266.py
+++ b/rfc6266.py
@@ -183,11 +183,11 @@ def parse_headers(content_disposition, location=None, relaxed=False):
         return ContentDisposition(location=location)
 
     # Both alternatives seem valid.
-    if False:
+    #if False:
         # Require content_disposition to be ascii bytes (0-127),
         # or characters in the ascii range
-        content_disposition = ensure_charset(content_disposition, 'ascii')
-    else:
+        #content_disposition = ensure_charset(content_disposition, 'ascii')
+    #else:
         # We allow non-ascii here (it will only be parsed inside of
         # qdtext, and rejected by the grammar if it appears in
         # other places), although parsing it can be ambiguous.
@@ -195,7 +195,7 @@ def parse_headers(content_disposition, location=None, relaxed=False):
         # won't get dismissed because of an unrelated ambiguity
         # in the filename parameter. But it does mean we occasionally
         # give less-than-certain values for some legacy senders.
-        content_disposition = ensure_charset(content_disposition, 'iso-8859-1')
+        #content_disposition = ensure_charset(content_disposition, 'iso-8859-1')
 
     # Check the caller already did LWS-folding (normally done
     # when separating header names and values; RFC 2616 section 2.2

--- a/rfc6266.py
+++ b/rfc6266.py
@@ -396,7 +396,8 @@ def qd_quote(text):
 
 
 def build_header(
-    filename, disposition='attachment', filename_compat=None
+    filename, disposition='attachment', filename_compat=None,
+    **keys
 ):
     """Generate a Content-Disposition header for a given filename.
 
@@ -427,6 +428,9 @@ def build_header(
 
     rv = disposition
 
+    for key in keys:
+        rv += '; {}={}'.format(key, keys[key])
+
     if is_token(filename):
         rv += '; filename=%s' % (filename, )
         return rv
@@ -451,4 +455,3 @@ def build_header(
 
     # This will only encode filename_compat, if it used non-ascii iso-8859-1.
     return rv.encode('iso-8859-1')
-

--- a/rfc6266.py
+++ b/rfc6266.py
@@ -429,14 +429,14 @@ def build_header(
 
     if is_token(filename):
         rv += '; filename=%s' % (filename, )
-        return rv
+        return rv.encode('iso-8859-1')
     elif is_ascii(filename) and is_lws_safe(filename):
         qd_filename = qd_quote(filename)
         rv += '; filename="%s"' % (qd_filename, )
         if qd_filename == filename:
             # RFC 6266 claims some implementations are iffy on qdtext's
             # backslash-escaping, we'll include filename* in that case.
-            return rv
+            return rv.encode('iso-8859-1')
     elif filename_compat:
         if is_token(filename_compat):
             rv += '; filename=%s' % (filename_compat, )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     url='https://github.com/g2p/rfc6266',
     keywords='rfc6266 Content-Disposition http attachments',
     name='rfc6266',
-    version='0.0.4',  # semver
+    version='0.0.5',  # semver
     license='GNU LGPL',
     platforms='OS-independent',
     py_modules=['rfc6266', 'test_rfc6266'],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     url='https://github.com/g2p/rfc6266',
     keywords='rfc6266 Content-Disposition http attachments',
     name='rfc6266',
-    version='0.0.5',  # semver
+    version='0.0.6',  # semver
     license='GNU LGPL',
     platforms='OS-independent',
     py_modules=['rfc6266', 'test_rfc6266'],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     url='https://github.com/g2p/rfc6266',
     keywords='rfc6266 Content-Disposition http attachments',
     name='rfc6266',
-    version='0.0.6',  # semver
+    version='0.0.6.op1',  # semver
     license='GNU LGPL',
     platforms='OS-independent',
     py_modules=['rfc6266', 'test_rfc6266'],

--- a/test_rfc6266.py
+++ b/test_rfc6266.py
@@ -14,8 +14,8 @@ def test_parsing():
         'attachment; filename=simple').filename_unsafe == 'simple'
 
     # test ISO-8859-1
-    fname = parse_headers(u'attachment; filename="oyé"').filename_unsafe
-    assert fname == u'oyé', repr(fname)
+    fname = parse_headers('attachment; filename="oyé"').filename_unsafe
+    assert fname == 'oyé', repr(fname)
 
     cd = parse_headers(
         'attachment; filename="EURO rates";'

--- a/test_rfc6266.py
+++ b/test_rfc6266.py
@@ -80,7 +80,6 @@ def test_relaxed():
     assert cd.filename_unsafe == u'spa ced'
 
 
-
 def test_roundtrip():
     def roundtrip(filename):
         return parse_headers(build_header(filename)).filename_unsafe
@@ -95,3 +94,10 @@ def test_roundtrip():
     assert_roundtrip('a\"b')
     assert_roundtrip(u'aéio   o♥u"qfsdf!')
 
+
+def test_test_roundtrip():
+    assert (build_header("test.txt", disposition='form-data', name="test1")
+            == 'form-data; name=test1; filename=test.txt')
+
+    assert (build_header(u"тест.txt", disposition='form-data', name="test2")
+            == "form-data; name=test2; filename*=utf-8''%D1%82%D0%B5%D1%81%D1%82.txt")


### PR DESCRIPTION
I would like to build a Content-Disposition header like:
`content-disposition: form-data; name="userfile"; filename="$filename"`
